### PR TITLE
Fix latin1 vs. utf8 atom unpacking

### DIFF
--- a/src/unpacker.js
+++ b/src/unpacker.js
@@ -146,7 +146,7 @@ class Unpacker {
 			}
 			case 100: case 115: case 118: case 119: { // atom
 				const length = type === 100 || type === 118 ? (this._d[this._i++] << 8) + this._d[this._i++] : this._d[this._i++];
-				return this._resolveAtom(length, type < 118);
+				return this._resolveAtom(length, type >= 118);
 			}
 			case 104: case 105: case 108: { // tuple / large tuple / list
 				let length;


### PR DESCRIPTION
I noticed that UTF8 atoms (type 119, or [SMALL_ATOM_UTF8_EXT](https://www.erlang.org/doc/apps/erts/erl_ext_dist.html#small_atom_ext-deprecated)) were being decoded through the latin1 codepath. I think that's because this check [here](https://github.com/timotejroiko/wetf/blob/50fcf930efd427779b614632a8db066e045cd7ad/src/unpacker.js#L149
):

```js
case 100: case 115: case 118: case 119: { // atom
	const length = type === 100 || type === 118 ? (this._d[this._i++] << 8) + this._d[this._i++] : this._d[this._i++];
	return this._resolveAtom(length, type < 118);
}
```

... sets the utf argument of _resolveAtom to true when type < 118, which I think is inverted—the tags are:

- 100 ATOM_EXT (latin1)
- 115 SMALL_ATOM_EXT (latin1)
- 118 ATOM_UTF8_EXT (utf8)
- 119 SMALL_ATOM_UTF8_EXT (utf8)

Fixes: #1 